### PR TITLE
Fix for "Horizontal scroll not updating "

### DIFF
--- a/Demo/Assets/Scripts/InfiniteScroll/InfiniteScroll.cs
+++ b/Demo/Assets/Scripts/InfiniteScroll/InfiniteScroll.cs
@@ -408,7 +408,7 @@ namespace Mopsicus.InfiniteScroll {
 			if (_leftPosition < 0f) {
 				return;
 			}
-        	if (!_positions.ContainsKey(_previousPosition) || !_heights.ContainsKey(_previousPosition)) {
+        	if (!_positions.ContainsKey(_previousPosition) || !_widths.ContainsKey(_previousPosition)) {
             	return;
         	}				
 			float itemPosition = Mathf.Abs (_positions[_previousPosition]) + _widths[_previousPosition];


### PR DESCRIPTION
This is a pull-request for issue #20 I raised a short while ago.
due to the issue, you are not able to use the asset in horizontal mode, as updating cannot be completed, due to the heights variable always being empty