### PR TITLE
BugFix: Using the scrollbar to scroll results in the viewport not updated.

### DIFF
--- a/Runtime/Scroller.cs
+++ b/Runtime/Scroller.cs
@@ -537,6 +537,17 @@ namespace UIS {
         /// Handler on scroller
         /// </summary>
         void OnScrollChange(Vector2 vector) {
+            // Note: If the scroller position changed but the scroll velocity is exactly zero,
+            //       the movement was done via a scrollbar. In this case, we need to ScrollTo()
+            //       the indicated position directly.
+            // Note 2: The normalized scrollbar position is opposite from the ScrollTo() index.
+            //         This is why the we take (1.0 - scrollPos) instead of scrollPos directly.
+            if (_scroll.velocity.magnitude == 0.0f) {
+                var scrollPos = (Type == 0) ? vector.y : vector.x;
+                var newIndex = Mathf.RoundToInt(_count * (1.0f - scrollPos));
+                ScrollTo(newIndex);
+            }
+
             if (Type == 0) {
                 ScrollChangeVertical();
             } else {


### PR DESCRIPTION
I noticed that the items in the viewport don't update if you scroll using the elevator in the scrollbar instead of click-and-drag. (Everything works fine if you click and drag in the viewport.)

My solution is to update the scroll position with ScrollTo() when the position is changed by a scrollbar. I detect this condition by checking ScrollRect.velocity. If the velocity is zero, the position change was the result of elevator movement from the scrollbar.

(cherry picked from commit 36d0b9dbf21bb8049946217d2c4fa3f9eca638bd)