### PR TITLE
Changed ADDON_VIEWS_COUNT from a constant to a property

### DIFF
--- a/Runtime/Scroller.cs
+++ b/Runtime/Scroller.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
@@ -25,7 +25,7 @@ namespace UIS {
         /// <summary>
         /// Addon count views
         /// </summary>
-        const int ADDON_VIEWS_COUNT = 4;
+        public int AddonViewCount = 4;
 
         /// <summary>
         /// Velocity for scroll to function
@@ -955,7 +955,7 @@ namespace UIS {
                 index = 0;
             }
             if (index + _views.Length >= _count) {
-                index = _count - _views.Length + ADDON_VIEWS_COUNT;
+                index = _count - _views.Length + AddonViewCount;
             }
             for (var i = 0; i < _views.Length; i++) {
                 var position = (index < gap) ? index : index + i - gap;
@@ -1144,7 +1144,7 @@ namespace UIS {
                     height += item + ItemSpacing;
                 }
                 height /= _heights.Count;
-                var fillCount = Mathf.RoundToInt(_container.height / height) + ADDON_VIEWS_COUNT;
+                var fillCount = Mathf.RoundToInt(_container.height / height) + AddonViewCount;
                 _views = new GameObject[fillCount];
                 for (var i = 0; i < fillCount; i++) {
                     clone = Instantiate(Prefab, Vector3.zero, Quaternion.identity);
@@ -1190,7 +1190,7 @@ namespace UIS {
                     width += item + ItemSpacing;
                 }
                 width /= _widths.Count;
-                var fillCount = Mathf.RoundToInt(_container.width / width) + ADDON_VIEWS_COUNT;
+                var fillCount = Mathf.RoundToInt(_container.width / width) + AddonViewCount;
                 _views = new GameObject[fillCount];
                 for (var i = 0; i < fillCount; i++) {
                     clone = Instantiate(Prefab, Vector3.zero, Quaternion.identity);


### PR DESCRIPTION
Changed ADDON_VIEWS_COUNT from a constant to a property so that the value can be changed as needed in the application.

Edge case: if there are a lot of items of largely varying sizes, one of the items which should be off-screen when it is being recycled from top-to-bottom or vice versa flickers back and forth between both states. Adding more objects here helps hide this off screen. In my test case, I increased this to 16, but the exact number will vary based on the particular data.

(cherry picked from commit b5acf580a0ce566f8671cf97c42f13659ec6c508)